### PR TITLE
bft: remove duplicate get_ip_addr

### DIFF
--- a/bft
+++ b/bft
@@ -176,7 +176,7 @@ def main():
             def get_tftp_config(dev):
                 saved = config.console.logfile_read
                 config.console.logfile_read = None
-                config.console.tftp_server = dev.get_ip_addr("eth0")
+                config.console.tftp_server = dev.get_interface_ipaddr("eth0")
                 config.console.tftp_username = "root"
                 config.console.tftp_password = "bigfoot1"
                 config.console.tftp_port = "22"

--- a/devices/debian.py
+++ b/devices/debian.py
@@ -182,7 +182,7 @@ class DebianBox(base.BaseDevice):
                       self.password, self.port,
                       reboot=False)
 
-    def get_ip_addr(self, interface):
+    def get_interface_ipaddr(self, interface):
         self.sendline("\nifconfig %s" % interface)
         regex = ['addr:(\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}).*(Bcast|P-t-P):',
                  'inet (\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}).*(broadcast|P-t-P)']
@@ -219,7 +219,7 @@ class DebianBox(base.BaseDevice):
         self.start_sshd_server()
 
         try:
-            eth1_addr = self.get_ip_addr('eth1')
+            eth1_addr = self.get_interface_ipaddr('eth1')
         except:
             eth1_addr = None
 
@@ -430,7 +430,7 @@ EOF''')
             self.expect(self.prompt)
             self.sendline('dhclient eth1')
             self.expect(self.prompt)
-            self.gw = self.get_ip_addr("eth1")
+            self.gw = self.get_interface_ipaddr("eth1")
         else:
             self.sendline('ifconfig eth1 %s' % self.gw)
             self.expect(self.prompt)
@@ -441,7 +441,7 @@ EOF''')
         # configure routing
         self.sendline('sysctl net.ipv4.ip_forward=1')
         self.expect(self.prompt)
-        wan_ip_uplink = self.get_ip_addr("eth0")
+        wan_ip_uplink = self.get_interface_ipaddr("eth0")
         self.sendline('iptables -t nat -A POSTROUTING -o eth0 -j SNAT --to-source %s' % wan_ip_uplink)
         self.expect(self.prompt)
 

--- a/devices/openwrt_router.py
+++ b/devices/openwrt_router.py
@@ -121,14 +121,6 @@ class OpenWrtRouter(base.BaseDevice):
                 print(e)
                 print("\nWe appeared to have failed to break into U-Boot...")
 
-    def get_ip_addr(self, interface):
-        '''Return IP Address for given interface.'''
-        self.sendline("\nifconfig %s" % interface)
-        self.expect('addr:(\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}).*(Bcast|P-t-P):', timeout=5)
-        ipaddr = self.match.group(1)
-        self.expect(self.prompt)
-        return ipaddr
-
     def get_seconds_uptime(self):
         '''Return seconds since last reboot. Stored in /proc/uptime'''
         self.sendcontrol('c')

--- a/tests/ping.py
+++ b/tests/ping.py
@@ -43,7 +43,7 @@ class LanDevPingRouter(rootfs_boot.RootFSBootTest):
             msg = 'No LAN Device defined, skipping ping test from LAN.'
             lib.common.test_msg(msg)
             self.skipTest(msg)
-        router_ip = board.get_ip_addr(board.lan_iface)
+        router_ip = board.get_interface_ipaddr(board.lan_iface)
         lan.sendline('\nping -i 0.2 -c 5 %s' % router_ip)
         lan.expect('PING ')
         lan.expect('5 (packets )?received', timeout=15)


### PR DESCRIPTION
This was also called get_interface_ipaddr, so let's just use one

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>