### PR TITLE
devices: base: fix stack offsets for expect helper

### DIFF
--- a/devices/base.py
+++ b/devices/base.py
@@ -173,15 +173,18 @@ class BaseDevice(pexpect.spawn):
             return wrapper(pattern, *args, **kwargs)
 
         common.print_bold("%s = expecting: %s" %
-                              (error_detect.caller_file_line(2), repr(pattern)))
+                              (error_detect.caller_file_line(3), repr(pattern)))
         try:
             ret = wrapper(pattern, *args, **kwargs)
+
+            frame = error_detect.caller_file_line(3)
+
             if hasattr(self.match, "group"):
                 common.print_bold("%s = matched: %s" %
-                                  (error_detect.caller_file_line(1), repr(self.match.group())))
+                                  (frame, repr(self.match.group())))
             else:
                 common.print_bold("%s = matched: %s" %
-                                  (error_detect.caller_file_line(1), repr(pattern)))
+                                  (frame, repr(pattern)))
             return ret
         except:
             common.print_bold("expired")

--- a/devices/error_detect.py
+++ b/devices/error_detect.py
@@ -67,6 +67,12 @@ def detect_fatal_error(console):
     #detect_kernel_panic(console, s)
 
 def caller_file_line(i):
+    #line = 0
+    #print "##################### %s" % i
+    #for s in inspect.stack():
+    #    print "%s: %s" % (line, s)
+    #    line = line + 1
+    #print "##################### %s" % i
     caller = inspect.stack()[i] # caller of spawn or pexpect
     frame = caller[0]
     info = inspect.getframeinfo(frame)


### PR DESCRIPTION
Now we print the correct calling function for expect or send functions
when BFT_DEBUG is set in the environment

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>