### PR TITLE
devices: rpi3: add support to flash complete SD image

### DIFF
--- a/devices/rpi.py
+++ b/devices/rpi.py
@@ -180,7 +180,7 @@ class RPI(openwrt_router.OpenWrtRouter):
         self.sendline('setenv bootargs "$bcm_bootargs %s"' % bootargs)
         self.expect(self.uprompt)
 
-        self.sendline("setenv bootcmd 'fatload mmc 0 ${kernel_addr_r} %s; bootm ${kernel_addr_r} - ${fdt_addr}; booti ${kernel_addr_r} - ${fdt_addr}'" % self.kernel_file)
+        self.sendline("setenv bootcmd 'fatload mmc 0 ${kernel_addr_r} %s; bootm ${kernel_addr_r} - ${fdt_addr}; booti ${kernel_addr_r} - ${fdt_addr}'" % getattr(self, 'kernel_file', 'uImage'))
         self.expect(self.uprompt)
         self.sendline('saveenv')
         self.expect(self.uprompt)


### PR DESCRIPTION
This will flash a complete SD image after Linux is booted. This is done
incase u-boot env sector is corrupt or you just want to risk flashing an
entire image.

If the image is bad, the board will be bricked

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>