### PR TITLE
devices: debian: remove duplicate time-servers option in cmts dhcp co…

### DIFF
--- a/devices/debian.py
+++ b/devices/debian.py
@@ -364,7 +364,6 @@ next-server 192.168.3.1;
 default-lease-time 604800;
 max-lease-time 604800;
 allow leasequery;
-option time-servers 192.168.3.222;
 
 option space docsis-mta;
 option docsis-mta.dhcp-server-1 code 1 = ip-address;


### PR DESCRIPTION
…nfig

This was causing the wrong time server to be set on the server

Reported-by: Rachel Lei <rlei@libertyglobal.com>
Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>