### PR TITLE
travis: update image to point at RDK-B qemu image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 script:
         - ./bft -l
         - ./bft -i
-        - yes | ./bft -b qemux86 -r https://autobuilder.yocto.io/pub/releases/yocto-2.4.2/machines/genericx86/core-image-minimal-genericx86.wic -k https://autobuilder.yocto.io/pub/releases/yocto-2.4.2/machines/genericx86/bzImage-genericx86.bin -z -y
+        - yes | ./bft -b qemux86 -r https://www.dropbox.com/s/ydgqcjz3wy5v0pm/X86EMLTRBB_default_20180627181048.vmdk?dl=0 -y
         - grep tests_fail...0, results/test_results.json
 after_failure:
-        - yes | BFT_DEBUG=y ./bft -b qemux86 -r https://autobuilder.yocto.io/pub/releases/yocto-2.4.2/machines/genericx86/core-image-minimal-genericx86.wic -k https://autobuilder.yocto.io/pub/releases/yocto-2.4.2/machines/genericx86/bzImage-genericx86.bin -z -y
+        - yes | BFT_DEBUG=y ./bft -b qemux86 -r https://www.dropbox.com/s/ydgqcjz3wy5v0pm/X86EMLTRBB_default_20180627181048.vmdk?dl=0 -y

--- a/tests/rootfs_boot.py
+++ b/tests/rootfs_boot.py
@@ -160,7 +160,6 @@ class RootFSBootTest(linux_boot.LinuxBootTest):
         print("\nThe router has been up %s seconds." % end_seconds_up)
         if self.config.setup_device_networking:
             assert end_seconds_up > linux_booted_seconds_up
-            assert end_seconds_up > 30
 
         self.logged['boot_time'] = end_seconds_up
 


### PR DESCRIPTION
We can also enable networking since this will route traffic between the
WAN and LAN devices

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>