### PR TITLE
devices: casa_cmts.py: fix logout issue

### DIFF
--- a/devices/casa_cmts.py
+++ b/devices/casa_cmts.py
@@ -63,6 +63,7 @@ class CasaCMTS(base.BaseDevice):
 
     def logout(self):
         self.sendline('exit')
+        self.sendline('exit')
 
     def check_online(self, cmmac):
         output = "offline"


### PR DESCRIPTION
When logout to exit cmts, it missed "exit" command to cmts terminal for 2 layer.
Add exit command.

Signed-off-by: sy_huang <sy_huang@compalbn.com>