### PR TITLE
devices: base.py:fix_get_interface_ip6addr

### DIFF
--- a/devices/base.py
+++ b/devices/base.py
@@ -31,7 +31,7 @@ class BaseDevice(pexpect.spawn):
 
     def get_interface_ip6addr(self, interface):
         self.sendline("\nifconfig %s" % interface)
-        self.expect('inet6 addr: (200(.+)) Scope:Global', timeout=5)
+        self.expect('inet6 addr: (200(.+))/\d+ Scope:Global', timeout=5)
         ipaddr = self.match.group(1)
         self.expect(self.prompt)
         return ipaddr


### PR DESCRIPTION
Fix regexp to get ipv6 function

ex:
inet6 addr: fe80::40ec:26b8:95a5:1132/64
function return 'fe80::40ec:26b8:95a5:1132/64' change to 'fe80::40ec:26b8:95a5:1132'

Signed-off-by: luke_tseng <luke_tseng@compalbn.com>