### PR TITLE
devices: windows_telnet: add inital device for a windows telnet device

### DIFF
--- a/devices/windows_telnet.py
+++ b/devices/windows_telnet.py
@@ -1,0 +1,33 @@
+
+import sys
+import base
+import connection_decider
+
+class WindowsTelnet(base.BaseDevice):
+
+    model = ('windows-telnet')
+    # This prompt regex could use more work
+    prompt = ['[a-zA-Z]:\\\\.*>$']
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+        self.ip = self.kwargs['ipaddr']
+        self.username = self.kwargs.get('username', 'Administrator')
+        self.password = self.kwargs.get('password', 'bigfoot1')
+
+        conn_cmd = "telnet %s" % self.ip
+
+        self.connection = connection_decider.connection("local_cmd", device=self, conn_cmd=conn_cmd)
+        self.connection.connect()
+        self.logfile_read = sys.stdout
+        self.linesep = '\r'
+
+        self.expect('login: ')
+        self.sendline(self.username)
+        self.expect('password: ')
+        self.sendline(self.password)
+        self.expect(self.prompt)
+
+        # Hide login prints, resume after that's done


### PR DESCRIPTION
This connects to a windows machine over telnet. Here is a basic example
test:
```
from devices import winwifi

class wintest(rootfs_boot.RootFSBootTest):
    def runTest(self):
        winwifi.sendline('dir')
        winwifi.expect(winwifi.prompt)
```
You can add a device in the boarfarm config via:
```
"devices": [
		{
			"name": "winwifi",
			"type": "windows-telnet",
			"ipaddr": "$ipaddr",
			"username": "user",
			"password": "pass"
		}
```
Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>