### PR TITLE
devices: debian: add functio nto extract tftp server ip address

### DIFF
--- a/devices/debian.py
+++ b/devices/debian.py
@@ -809,6 +809,10 @@ EOF''')
         except:
             self.expect(self.prompt, timeout=30)
 
+    def tftp_server_ip_int(self):
+        '''Returns the DUT facing side tftp server ip'''
+        return self.gw
+
 if __name__ == '__main__':
     # Example use
     try:


### PR DESCRIPTION
If a test needs to know the tftp server IP address that the DUT can see
then they need to use this function to parse it

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>