### PR TITLE
devices: local_cmd: skip to next device if cmd closes

### DIFF
--- a/devices/local_cmd.py
+++ b/devices/local_cmd.py
@@ -9,9 +9,13 @@ class LocalCmd():
         self.conn_cmd = conn_cmd
 
     def connect(self):
-        pexpect.spawn.__init__(self.device,
-                           command='/bin/bash',
-                           args=['-c', self.conn_cmd])
+        try:
+            pexpect.spawn.__init__(self.device,
+                               command='/bin/bash',
+                               args=['-c', self.conn_cmd])
+            self.device.expect(pexpect.TIMEOUT, timeout=5)
+        except pexpect.EOF as e:
+            raise Exception("Board is in use (connection refused).")
 
     def close():
         self.device.sendcontrol('c')


### PR DESCRIPTION
This will simply fail if we don't connect to the device via this
comamnd. Let's raise an exception instead so it backs out and trys
another board if one is available

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>