### PR TITLE
html: scan all overlays for html and use first one in overlay list

### DIFF
--- a/make_human_readable.py
+++ b/make_human_readable.py
@@ -31,10 +31,13 @@ def pick_template_filename():
     basic = owrt_tests_dir+"/html/template_results_basic.html"
     full = owrt_tests_dir+"/html/template_results.html"
     if 'BFT_OVERLAY' in os.environ:
-        if os.path.isfile(os.environ['BFT_OVERLAY'] + "/html/template_results_basic.html"):
-            basic = os.environ['BFT_OVERLAY'] + "/html/template_results_basic.html"
-        if os.path.isfile(os.environ['BFT_OVERLAY'] + "/html/template_results.html"):
-            full = os.environ['BFT_OVERLAY'] + "/html/template_results.html"
+        for overlay in os.environ['BFT_OVERLAY'].split(' '):
+            if os.path.isfile(overlay + "/html/template_results_basic.html"):
+                basic = overlay + "/html/template_results_basic.html"
+                break
+            if os.path.isfile(overlay + "/html/template_results.html"):
+                full = overlay + "/html/template_results.html"
+                break
 
     templates = {'basic': basic,
                  'full': full}


### PR DESCRIPTION
This fixes regressions where we did not use the template in the html dir

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>