### PR TITLE
tests: rootfs_boot: start tftp server after configure

### DIFF
--- a/devices/debian.py
+++ b/devices/debian.py
@@ -314,15 +314,13 @@ class DebianBox(base.BaseDevice):
             eth1_addr = None
 
         # set WAN ip address, for now this will always be this address for the device side
-        if self.gw != eth1_addr:
-            self.sendline('ifconfig eth1 down')
-            self.expect(self.prompt)
-
-        # set WAN ip address, for now this will always be this address for the device side
         # TODO: fix gateway for non-WAN tftp_server
         if self.gw != eth1_addr:
             self.sendline('ifconfig eth1 %s' % getattr(self, 'gw', '192.168.0.1'))
             self.expect(self.prompt)
+
+        self.sendline('ifconfig eth1 up')
+        self.expect(self.prompt)
 
         #configure tftp server
         self.sendline('/etc/init.d/tftpd-hpa stop')

--- a/tests/rootfs_boot.py
+++ b/tests/rootfs_boot.py
@@ -46,10 +46,10 @@ class RootFSBootTest(linux_boot.LinuxBootTest):
         if prov is not None:
             prov.provision_board(self.config.board)
 
-        tftp_device.start_tftp_server()
-
         if lan:
             lan.configure(kind="lan_device")
+
+        tftp_device.start_tftp_server()
 
         board.reset()
         rootfs = None


### PR DESCRIPTION
We do a lot more things in the configure step now including turn off
eth1 and trying to install packages from the host network so it will
leave us in a bad state, so let's start the tftp server right after that
and then also make sure the interface is up

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>