### PR TITLE
bft: support multiple golden masters

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -77,7 +77,7 @@ def parse():
     parser.add_argument('-z', '--no-network', action='store_true', help='Skip basic network tests when booting')
     parser.add_argument('-c', '--config_file', metavar='', type=str, default=boardfarm_config_location, help='JSON config file for boardfarm')
     parser.add_argument('--bootargs', metavar='', type=str, default=None, help='bootargs to set or append to default args (board dependant)')
-    parser.add_argument('-g', '--golden', metavar='', type=str, default=None, help='Path to JSON results to compare against (golden master)')
+    parser.add_argument('-g', '--golden', metavar='', type=str, default=[], nargs='+', help='Path to JSON results to compare against (golden master)')
     parser.add_argument('-q', '--feature', metavar='', type=str, default=[], nargs='+', help='Features required for this test run')
 
     args = parser.parse_args()

--- a/bft
+++ b/bft
@@ -290,15 +290,14 @@ def main():
     os.environ['TEST_END_TIME'] = datetime.datetime.now().strftime("%s")
 
     # grab golden master results
-    try:
-        if config.golden is not None:
-            import requests
-            golden = requests.get(config.golden).json()
-        else:
-            golden = {}
-    except:
-        print_bold("Failed to fetch golden master results, skipping...")
-        golden = {}
+    golden = {}
+    if config.golden is not []:
+        import requests
+        for g in golden:
+            try:
+                golden.update(requests.get(config.golden).json())
+            except:
+                print_bold("Failed to fetch golden master results, skipping...")
 
     # Write test result messages to a file
     full_results = library.process_test_results(tests_to_run, golden)


### PR DESCRIPTION
There are so many different tests runs possible, we want to be able to
aggregate a few together so when we run tests we can always have a
baseline to compare against.

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>