### PR TITLE
devices: base.py: modify regex of get_interface_ip6addr()

### DIFF
--- a/devices/base.py
+++ b/devices/base.py
@@ -31,7 +31,7 @@ class BaseDevice(pexpect.spawn):
 
     def get_interface_ip6addr(self, interface):
         self.sendline("\nifconfig %s" % interface)
-        self.expect('inet6 addr: (200(.+))/\d+ Scope:Global', timeout=5)
+        self.expect('\s((200([0-9a-f]){1,1}:)([0-9a-f]{1,4}:){1,6}([0-9a-f]{1,4}))([\/\s])', timeout=5)
         ipaddr = self.match.group(1)
         self.expect(self.prompt)
         return ipaddr


### PR DESCRIPTION
- inet6 format is different between board.get_interface_ip6addr("wan0") and wan.get_interface_ip6addr("eth1")
    - 'inet6 addr: 2001:b030:701d:2100:b593:1b01:313:ae00/128 Scope:Global' for board.get_interface_ip6addr("wan0")
    - 'inet6 2002:db50:fa13:1:78fe:23ff:feef:f0ac  prefixlen 64' for wan.get_interface_ip6addr("eth1")
    - modify regex to self.expect('\s((200([0-9a-f]){1,1}:)([0-9a-f]{1,4}:){1,6}([0-9a-f]{1,4}))([\/\s])', timeout=5)

Signed-off-by: luke <luke_tseng@compalbn.com>