### PR TITLE
devices: casa_cmts: timeout increase

### DIFF
--- a/devices/casa_cmts.py
+++ b/devices/casa_cmts.py
@@ -39,7 +39,7 @@ class CasaCMTS(base.BaseDevice):
 
     def connect(self):
         try:
-            if 0 == self.expect(['login:', pexpect.TIMEOUT], timeout=3):
+            if 0 == self.expect(['login:', pexpect.TIMEOUT], timeout=10):
                 self.sendline(self.username)
                 self.expect('assword:')
                 self.sendline(self.password)
@@ -49,7 +49,7 @@ class CasaCMTS(base.BaseDevice):
                 # over serial it could be stale so we try to recover
                 self.sendline('q')
                 self.sendline('exit')
-                self.expect([pexpect.TIMEOUT] + self.prompt, timeout=5)
+                self.expect([pexpect.TIMEOUT] + self.prompt, timeout=20)
             self.sendline('enable')
             if 0 == self.expect(['Password:'] + self.prompt):
                 self.sendline(self.password)


### PR DESCRIPTION
increased the value of 2 timeouts in CasaCMTS.connect that seemed too optimistic
3s -> 10s
5s -> 20s

Signed-off-by: Michele Gualco <mgualco.contractor@libertyglobal.com>