### PR TITLE
devices: casa_cmts: add early auth encry ranging option

### DIFF
--- a/devices/casa_cmts.py
+++ b/devices/casa_cmts.py
@@ -256,6 +256,8 @@ class CasaCMTS(base.BaseDevice):
         self.expect(self.prompt)
         self.sendline('no shutdown')
         self.expect(self.prompt)
+        self.sendline('early-authentication-encryption ranging')
+        self.expect(self.prompt)
         self.sendline('no dhcp-authorization')
         self.expect(self.prompt)
         self.sendline('no multicast-dsid-forward')


### PR DESCRIPTION
This will help some CMs come online faster

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>