### PR TITLE
devices: base.py: add .strip() to return string

### DIFF
--- a/devices/base.py
+++ b/devices/base.py
@@ -61,7 +61,7 @@ class BaseDevice(pexpect.spawn):
         except Exception as e:
             self.sendcontrol('c')
             raise Exception("Command did not complete within %s seconds. Prompt was not seen." % timeout)
-        return self.before
+        return self.before.strip()
 
     def write(self, string):
         self._logfile_read.write(string)


### PR DESCRIPTION
- self.before.strip() instead of self.before

Signed-off-by: luke <luke_tseng@compalbn.com>