### PR TITLE
devices: debian: fix issues with bridged mode

### DIFF
--- a/devices/debian.py
+++ b/devices/debian.py
@@ -753,6 +753,10 @@ EOF''')
         self.expect(self.prompt)
         self.sendline('rm /var/lib/dhcp/dhclient.leases')
         self.expect(self.prompt)
+        self.sendline("sed -e 's/mv -f $new_resolv_conf $resolv_conf/cat $new_resolv_conf > $resolv_conf/g' -i sbin/dhclient-script")
+        self.expect(self.prompt)
+        self.sendline('ip route del default dev eth0')
+        self.expect(self.prompt)
         for attempt in range(3):
             try:
                 self.sendline('dhclient -v eth1')


### PR DESCRIPTION
In bridged mode the lan_gateway will (most likely) not be the gateway
for the lan device. So we will update our lan_{gateway,network}
attributes.

Secondly, no reason to del the default route and add it back let's just
keep that set.

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>