### PR TITLE
tests: lib: randomMAC.py added

### DIFF
--- a/deploy-boardfarm-nodes.sh
+++ b/deploy-boardfarm-nodes.sh
@@ -7,20 +7,8 @@ OPTS=${4:-"both"} # both, odd, even, odd-dhcp, even-dhcp
 BRINT=br-bft
 BF_IMG=${BF_IMG:-"bft:node"}
 
-random_private_mac () {
-	python - <<END
-import random
-#
-def randomMAC():
-	mac = [ 0x00, 0x16, 0x3e,
-		random.randint(0x00, 0x7f),
-		random.randint(0x00, 0xff),
-		random.randint(0x00, 0xff) ]
-	return ':'.join(map(lambda x: "%02x" % x, mac))
-#
-print randomMAC()
-END
-}
+
+random_private_mac () { m=`python  boardfarm/tests/lib/randomMAC.py`; echo $m ;}
 
 local_route () {
 	# TODO: This is a problem if the router network matches the host network

--- a/tests/lib/randomMAC.py
+++ b/tests/lib/randomMAC.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+
+
+import random
+
+def randomMAC():
+    mac = [ (random.randint(0x00,0xff)&0xfe), # the lsb is 0, i.e. no multicat bit
+             random.randint(0x00, 0xff),
+             random.randint(0x00, 0xff),
+             random.randint(0x00, 0xff),
+             random.randint(0x00, 0xff),
+             random.randint(0x00, 0xff) ]
+    mac_to_be_decided = ':'.join(map(lambda x : hex(x)[2:].lstrip("0x").zfill(2),mac))
+
+    return (mac_to_be_decided)
+
+print randomMAC()
+


### PR DESCRIPTION
    added a simple function for the creation of a random MAC
    address, with the multicast bit NOT set (first octet, lsb).
    Updated deploy_boardfarm shell script to invoke this python
    module.
    The following files still reference the old randomMAC function:
    devices/qcom_arm_base.py
    devices/openwrt_router.py

Signed-off-by: Prasada Reddy <preddy.contractor@libertyglobal.com>