### PR TITLE
config: updated BFT_OPTIONS

### DIFF
--- a/config.py
+++ b/config.py
@@ -49,13 +49,19 @@ cdrouter_lan_iface = os.environ.get('BFT_CDROUTERLANIFACE', "eth2")
 # this  will probably grow as options are added
 option_dict = {
         "proxy":["normal","sock5"],
-        "webdriver":["chrome","ffox"]
+        "webdriver":["chrome","ffox"],
+        "disp":["xvfb", "xephyr", "xvnc"],
+        "disp_port":["5904"],
+        "disp_size":["1366x768"]
         }
 
 # the syntax is
 # BFT_OPTIONS="proxy=normal webdriver=chrome"
 default_proxy_type = "normal"
 default_web_driver = "ffox"
+default_display_backend = "xvnc"
+default_display_backend_port = "5904"
+default_display_backend_size = "1366x768"
 
 if 'BFT_OPTIONS' in os.environ:
     for option in os.environ['BFT_OPTIONS'].split(' '):
@@ -65,9 +71,29 @@ if 'BFT_OPTIONS' in os.environ:
                 default_proxy_type = v
             if k == "webdriver":
                 default_web_driver  = v
+            if k == "disp":
+                default_display_backend = v
+        elif k == "disp_port":
+            # quick validation
+            i = int(v) # if not a valid num python will throw and exception
+            if not 1024 <= i <= 65535:
+                print("Warning: display backend port: %i not in range (1024-65535)" % i)
+                exit(1)
+            default_display_backend_port = v
+        elif k == "disp_size":
+            default_display_backend_size = v
         else:
             print("Warning: Ignoring option: %s (misspelled?)" % option)
 
+def get_display_backend_size():
+    xc,yc = default_display_backend_size.split('x')
+    x = int(xc)
+    y = int(yc)
+    return x,y
+
 if 'BFT_DEBUG' in os.environ:
-    print("Using default_proxy_type="+default_proxy_type)
-    print("Using default_web_driver="+default_web_driver)
+    print("Using proxy:"+default_proxy_type)
+    print("Using webdriver:"+default_web_driver)
+    print("Using disp:"+default_display_backend)
+    print("Using disp_port:"+default_display_backend_port)
+    print("Using disp_size:"+default_display_backend_size)

--- a/tests/screenshot_gui.py
+++ b/tests/screenshot_gui.py
@@ -8,6 +8,7 @@
 import rootfs_boot
 import lib
 from devices import board, wan, lan, prompt
+import config
 
 from pyvirtualdisplay import Display
 import pexpect
@@ -17,12 +18,13 @@ class ScreenshotGUI(rootfs_boot.RootFSBootTest):
     '''Starts Firefox via a proxy to the LAN and takes a screenshot'''
     def runTest(self):
         try:
+            x,y=config.get_display_backend_size()
             # try to start vnc server
-            self.display = Display(backend='xvnc', rfbport='5904', visible=0, size=(1366, 768))
+            self.display = Display(backend=config.default_display_backend, rfbport=config.default_display_backend_port, visible=0, size=(x, y))
             self.display.start()
 
             if "BFT_DEBUG" in os.environ:
-                print("Connect to VNC display running on localhost:5904")
+                print("Connect to VNC display running on localhost:"+config.default_display_backend_port)
                 raw_input("Press any key after connecting to display....")
         except:
             # fallback xvfb


### PR DESCRIPTION
    added:
        "disp":["xvfb", "xephyr", "xvnc"],
        "disp_port":["5904"],
        "disp_size":["1366x768"]
    with defaults:
	default_display_backend = "xvnc"
	default_display_backend_port = "5904"
	default_display_backend_size = "1366x768"
    screenshot_gui updated accordingly

Signed-off-by: Michele Gualco <mgualco.contractor@libertyglobal.com>