### PR TITLE
devices: casa_cmts: added get_cm_mac_cmts_format(mac)

### DIFF
--- a/devices/casa_cmts.py
+++ b/devices/casa_cmts.py
@@ -423,6 +423,17 @@ class CasaCMTS(base.BaseDevice):
         else:
             return True
 
+    # Function:   get_cm_mac_cmts_format(mac)
+    # Parameters: mac        (mac address XX:XX:XX:XX:XX:XX)
+    # returns:    the cm_mac in cmts format xxxx.xxxx.xxxx (lowercase)
+    def get_cm_mac_cmts_format(self, mac):
+        if mac == None:
+            return None
+        # the mac cmts syntax format example is 3843.7d80.0ac0
+        tmp = mac.replace(':', '')
+        mac_cmts_format = tmp[:4]+"."+tmp[4:8]+"."+tmp[8:]
+        return mac_cmts_format.lower()
+
     def check_docsis_mac_ip_provisioning_mode(self, index):
         self.sendline('show interface docsis-mac %s' % index)
         self.expect('ip-provisioning-mode (\w+\-\w+)')


### PR DESCRIPTION
helper function to convert a mac from XX:XX:XX:XX:XX:XX
to xxxx.xxxx.xxxx (casa cmts output format)

Signed-off-by: Michele Gualco <mgualco.contractor@libertyglobal.com>