### PR TITLE
html: template_results.html ; make_human_readable.py

### DIFF
--- a/html/template_results.html
+++ b/html/template_results.html
@@ -68,6 +68,7 @@
   <br>
   Board access:<br>
   <ul>
+    <li>Report completion time: ${report_time}</li>
     <li>Name: ${station}</li>
     <li>Router console: ${conn_cmd}</li>
     <li>Location: ${location}</li>

--- a/make_human_readable.py
+++ b/make_human_readable.py
@@ -11,7 +11,7 @@ import json
 import os
 import re
 import sys
-
+import time
 from string import Template
 try:
     from collections import Counter
@@ -99,7 +99,8 @@ def xmlresults_to_html(test_results,
                   'summary_title' : title,
                   'changes': changes_to_html(os.environ.get('change_list')),
                   "board_type": "unknown",
-                  "location": "unknown"}
+                  "location": "unknown",
+                  "report_time" : "unknown"}
     try:
         parameters.update(board_info)
         parameters['misc'] = build_station_info(board_info)
@@ -152,6 +153,16 @@ def xmlresults_to_html(test_results,
         parameters['total_test_time'] = "%s minutes" % (test_seconds/60)
     except:
         pass
+
+    # Report completion time
+    try:
+        end_timestamp = int(os.environ.get('TEST_END_TIME'))
+        struct_time = time.localtime(end_timestamp)
+        format_time = time.strftime("%Y-%m-%d %H:%M:%S", struct_time)
+        parameters['report_time'] = "%s" % (format_time)
+    except:
+        pass
+
     # Substitute parameters into template html to create new html file
     template_filename = pick_template_filename()
     f = open(template_filename, "r").read()


### PR DESCRIPTION
For NTL require, need report completion time inside result.html.
Photos attached with this modify.

Signed-off-by: gerben <gerben_chen@compalbn.com>

Board access:
•Report completion time: 2018-12-19 20:52:34
•Name: mv1-2-2
•Router console: [u'telnet 172.16.1.217 7003', u'telnet 172.16.1.217 7004']
•Location: taiwan-wifi-2
•wan debian
•lan debian
•provisioner cisco-cnr
•acs_server friendly_acs_soap
•wifi_2G cbn_wifi_2G
•wifi_5G cbn_wifi_5G
•cmts casa_cmts
