### PR TITLE
tests: linux_boot: now displays the test start/end time

### DIFF
--- a/tests/lib/logging.py
+++ b/tests/lib/logging.py
@@ -10,14 +10,14 @@ import types
 from datetime import datetime
 from devices.common import print_bold
 
-def now_short():
+def now_short(_format = "%Y%m%d-%H%M%S"):
     """
     Name:now_short
     Purpose: Get current date and time string
     Input:None
     Output:String in "YYYYMMDD-hhmmss" format
     """
-    timeString = time.strftime("%Y%m%d-%H%M%S", time.localtime())+"\t"
+    timeString = time.strftime(_format, time.localtime())+"\t"
     return timeString
 
 def logfile_assert_message(s, condition, message):

--- a/tests/linux_boot.py
+++ b/tests/linux_boot.py
@@ -13,13 +13,14 @@ import traceback
 import time
 
 from devices import board, wan, lan, wlan, prompt
-from lib.logging import LoggerMeta
+from lib.logging import LoggerMeta, now_short
 
 class LinuxBootTest(unittest2.TestCase):
     _testMethodName = "UNDEFINED"
     __metaclass__ = LoggerMeta
     log = ""
     log_calls = ""
+    _format = "%a %d %b %Y %H:%M:%S"
 
     def __init__(self, config):
         super(LinuxBootTest, self).__init__("testWrapper")
@@ -33,9 +34,9 @@ class LinuxBootTest(unittest2.TestCase):
         return self.__class__.__name__
 
     def setUp(self):
-        lib.common.test_msg("\n==================== Begin %s ====================" % self.__class__.__name__)
+        lib.common.test_msg("\n==================== Begin %s    Time: %s ====================" % (self.__class__.__name__, now_short(self._format)))
     def tearDown(self):
-        lib.common.test_msg("\n==================== End %s ======================" % self.__class__.__name__)
+        lib.common.test_msg("\n==================== End %s      Time: %s ======================" % (self.__class__.__name__, now_short(self._format)))
 
     def wan_setup(self):
         None
@@ -113,7 +114,7 @@ class LinuxBootTest(unittest2.TestCase):
                 self.result_grade = "Exp FAIL"
             else:
                 self.result_grade = "FAIL"
-            print("\n\n=========== Test failed! Running recovery ===========")
+            print("\n\n=========== Test failed! Running recovery Time: %s ===========" % now_short(self._format))
             if e.__class__.__name__ == "TIMEOUT":
                 print(e.get_trace())
             else:


### PR DESCRIPTION
Requested by the test architect, time is shown as follows:
====== Begin NTL7465LG__P3__541         Start Time: Sat 12 Jan 2019 22:05:31  ====
====== End NTL7465LG__P3__541           End Time: Sat 12 Jan 2019 22:15:31  ==

Signed-off-by: Michele Gualco <mgualco.contractor@libertyglobal.com>