### PR TITLE
tests: lib: common: add helper function to dynamically create a new test

### DIFF
--- a/tests/lib/common.py
+++ b/tests/lib/common.py
@@ -176,3 +176,6 @@ class TestResult:
         self.result_message = message
 
 cmd_exists = lambda x: any(os.access(os.path.join(path, x), os.X_OK) for path in os.environ["PATH"].split(os.pathsep))
+
+def newClass(newclsname, basecls=(object,), clsattrs={}):
+    globals()[newclsname] = type(newclsname, basecls, clsattrs)


### PR DESCRIPTION
This function will insert a new test class into the globals() so bft
will see it and be able to execute it. It's typical use is to have a
base class as a parent that does the brunt of the work and some
attributes we can add to make it behave differently.

You can though add functions as attributes and build tests dynamically
that way as well.

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>