### PR TITLE
tests: lib: installers: the openvpn-install.sh is no longer curled

### DIFF
--- a/tests/lib/installers.py
+++ b/tests/lib/installers.py
@@ -383,6 +383,19 @@ def install_ovpn_server(device, remove=False, _user='lan', _ip="ipv4"):
     device.sendline('cd')
     device.expect_exact('cd')
     device.expect(device.prompt)
+
+    # This is where the original setup script comes from. For conveninence we shall
+    # copy the version commited in test/lib/scripts to the server (we cannot always
+    # guarantee tha the containers will have web access)
+    #device.sendline('curl -O https://raw.githubusercontent.com/Angristan/openvpn-install/master/openvpn-install.sh')
+    import os
+    ovpn_install_script = 'openvpn-install.sh'
+    fname = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'scripts/'+ovpn_install_script)
+    dest = '/root/'+ovpn_install_script
+    device.copy_file_to_server(fname, dest)
+    device.sendline('chmod +x openvpn-install.sh')
+    device.expect(device.prompt)
+
     device.sendline('ls -l /etc/init.d/openvpn')
     index = device.expect(['(\\s{1,}\\d{4}()\\s{1,}\\/etc\\/init\\.d\\/openvpn)'] + device.prompt, timeout=90)
 
@@ -406,10 +419,6 @@ def install_ovpn_server(device, remove=False, _user='lan', _ip="ipv4"):
     if index != 0:
         dev_ip = device.get_interface_ipaddr(device.iface_dut)
         device.sendline('apt-get update')
-        device.expect(device.prompt)
-        device.sendline('curl -O https://raw.githubusercontent.com/Angristan/openvpn-install/master/openvpn-install.sh')
-        device.expect(device.prompt, timeout=90)
-        device.sendline('chmod +x openvpn-install.sh')
         device.expect(device.prompt)
         device.sendline('./openvpn-install.sh')
         device.expect('IP address:.*', timeout=120)


### PR DESCRIPTION
Now use the committed openvpn-install.sh instead of curling it
every time. The curl line was left for reference (commented out).

Signed-off-by: Michele Gualco <mgualco.contractor@libertyglobal.com>