### PR TITLE
tests: lib: installers: added function to install postfix

### DIFF
--- a/tests/lib/common.py
+++ b/tests/lib/common.py
@@ -323,3 +323,69 @@ EOF'''%(ip, port, cert))
         if "BFT_DEBUG" in os.environ:
             print_bold("Service started on ["+ip+"]:"+port)
         return True
+
+def configure_postfix(device):
+    '''
+    configures TSL and SSL ports to access postfix server
+    The function can be extended with configuration changes to test emails.
+    '''
+    device.sendline ('''cat > /etc/postfix/master.cf << EOF
+smtp      inet  n       -       y       -       -       smtpd
+465      inet  n       -       n       -       -       smtpd
+587      inet  n       -       n       -       -       smtpd
+smtp      inet  n       -       y       -       1       postscreen
+smtpd     pass  -       -       y       -       -       smtpd
+
+#628       inet  n       -       y       -       -       qmqpd
+pickup    unix  n       -       y       60      1       pickup
+cleanup   unix  n       -       y       -       0       cleanup
+qmgr      unix  n       -       n       300     1       qmgr
+#qmgr     unix  n       -       n       300     1       oqmgr
+tlsmgr    unix  -       -       y       1000?   1       tlsmgr
+rewrite   unix  -       -       y       -       -       trivial-rewrite
+bounce    unix  -       -       y       -       0       bounce
+defer     unix  -       -       y       -       0       bounce
+trace     unix  -       -       y       -       0       bounce
+verify    unix  -       -       y       -       1       verify
+flush     unix  n       -       y       1000?   0       flush
+proxymap  unix  -       -       n       -       -       proxymap
+proxywrite unix -       -       n       -       1       proxymap
+smtp      unix  -       -       y       -       -       smtp
+relay     unix  -       -       y       -       -       smtp
+        -o syslog_name=postfix/$service_name
+#       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
+showq     unix  n       -       y       -       -       showq
+error     unix  -       -       y       -       -       error
+retry     unix  -       -       y       -       -       error
+discard   unix  -       -       y       -       -       discard
+local     unix  -       n       n       -       -       local
+virtual   unix  -       n       n       -       -       virtual
+lmtp      unix  -       -       y       -       -       lmtp
+anvil     unix  -       -       y       -       1       anvil
+scache    unix  -       -       y       -       1       scache
+#
+
+maildrop  unix  -       n       n       -       -       pipe
+  flags=DRhu user=vmail argv=/usr/bin/maildrop -d ${recipient}
+
+#
+uucp      unix  -       n       n       -       -       pipe
+  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
+#
+# Other external delivery methods.
+#
+ifmail    unix  -       n       n       -       -       pipe
+  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
+bsmtp     unix  -       n       n       -       -       pipe
+  flags=Fq. user=bsmtp argv=/usr/lib/bsmtp/bsmtp -t$nexthop -f$sender $recipient
+scalemail-backend unix  -       n       n       -       2       pipe
+  flags=R user=scalemail argv=/usr/lib/scalemail/bin/scalemail-store ${nexthop} ${user} ${extension}
+mailman   unix  -       n       n       -       -       pipe
+  flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
+  ${nexthop} ${user}
+EOF''')
+    device.expect(device.prompt, timeout = 10)
+    device.sendline("service postfix start")
+    device.expect(device.prompt)
+    device.sendline("service postfix reload")
+    assert 0 != device.expect(['failed']+ device.prompt, timeout = 20) , "Unable to reolad server with new configurations"

--- a/tests/lib/installers.py
+++ b/tests/lib/installers.py
@@ -525,3 +525,23 @@ def install_pptp_client(device, remove=False):
         device.sendline('apt-get install pptp-linux -y')
 
     device.expect(device.prompt, timeout=60)
+
+def install_postfix(device):
+    '''Install postfix server if not present.'''
+    device.sendline('postconf -d | grep mail_version')
+    try:
+        device.expect('mail_version =', timeout=5)
+        device.expect(device.prompt)
+    except:
+        device.expect(device.prompt)
+        device.sendline('apt-get update') # Update inetd before installation
+        device.expect(device.prompt, timeout=90)
+        device.sendline("apt-get install postfix -y")
+        assert 0 == device.expect(['General type of mail configuration:']+ device.prompt, timeout = 90), "Mail configuration type is note received. Installaion failed"
+        device.sendline("2")
+        assert 0 == device.expect(['System mail name:']+ device.prompt, timeout = 90), "System mail name option is note received. Installaion failed"
+        device.sendline("testingsmtp.com")
+        assert 0 != device.expect(['Errors were encountered']+ device.prompt, timeout = 90), "Errors Encountered. Installaion failed"
+
+        device.sendline("service postfix start")
+        assert 0 != device.expect(['failed']+ device.prompt, timeout = 90), "Unable to start Postfix service.Installaion failed"


### PR DESCRIPTION
  -postfix server is used to install SMTP servers locally

tests: lib: common: added function to configure postfix SMTP server

  -As of now function configures postfix to allow access for clients on TLS and SSL port numbers
  -The function can be extended to configure mail server and for mail communication

Signed-off-by: Prem Kumar K N <prekumar.contractor@libertyglobal.com>