### PR TITLE
tests: lib: common: added function to enable/disable IPV6 in linux

### DIFF
--- a/tests/lib/common.py
+++ b/tests/lib/common.py
@@ -445,3 +445,10 @@ def snmp_mib_get(device, board, iface_ip, mib_name, index, timeout=10, retry=3):
     snmp_out = device.match.group(1)
     device.expect(device.prompt)
     return snmp_out
+
+def linux_ipv6_enable_disable(device, interface, option):
+    """
+    option 1 = Disable, Option 0=Enable
+    """
+    device.sendline("sysctl net.ipv6.conf."+interface+".disable_ipv6="+option)
+    device.expect(device.prompt, timeout=60)


### PR DESCRIPTION
    -The function will enable/disable IPv6 in linux clients based on value 1/0
    -1 to Disable, 0 to enable

Signed-off-by: prekumar.contractor <prekumar.contractor@libertyglobal.com>