### PR TITLE
deploy-boardfarm-nodes: Ketan's changes

### DIFF
--- a/deploy-boardfarm-nodes.sh
+++ b/deploy-boardfarm-nodes.sh
@@ -30,10 +30,11 @@ END
 
 local_route () {
 	# TODO: This is a problem if the router network matches the host network
-	host_dev=$(ip route list | grep ^default |  awk '{print $5}' )
-	local_route=$(ip route | grep "dev $host_dev" | grep src | awk '{print $1}' | head -n1)
-	docker0=$(ip -4 addr show docker0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
-	docker exec $cname ip route add $local_route dev eth0 via $docker0
+        docker0=$(ip -4 addr show docker0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
+        # moving the default route for eth0 (docker0 interface) and add it to table 102
+        docker exec $cname ip route del  default
+        docker exec $cname ip route add default  dev eth0 via $docker0 table 102
+        docker exec $cname ip rule add from $(docker exec $cname ip route|awk '{print $1}') table 102
 }
 
 # eth0 is docker private network, eth1 is vlan on specific interface


### PR DESCRIPTION
moved the default route from eth0 to table 102
on Ketan's behalf

Signed-off-by: Michele Gualco <mgualco.contractor@libertyglobal.com>