### PR TITLE
tests: rootfs_boot: fix logic for checking IP address

### DIFF
--- a/tests/rootfs_boot.py
+++ b/tests/rootfs_boot.py
@@ -192,8 +192,10 @@ class RootFSBootTest(linux_boot.LinuxBootTest):
                     try:
                         ip = board.get_interface_ipaddr(board.wan_iface)
                     except:
-                        assert ipaddress.IPv4Address(ip.decode('utf-8')) in prov.cm_network, \
-                            "Board failed to obtain WAN IP address"
+                        continue
+
+                    assert ipaddress.IPv4Address(ip.decode('utf-8')) in prov.cm_network, \
+                        "Board failed to obtain WAN IP address"
 
                     ips += [ip]
 
@@ -201,17 +203,22 @@ class RootFSBootTest(linux_boot.LinuxBootTest):
                         try:
                             ip = board.get_interface_ipaddr(board.erouter_iface)
                         except:
-                            assert ipaddress.IPv4Address(ip.decode('utf-8')) in prov.open_network, \
-                                "Board failed to obtain erouter IP address"
+                            continue
+
+                        assert ipaddress.IPv4Address(ip.decode('utf-8')) in prov.open_network, \
+                            "Board failed to obtain erouter IP address"
                         ips += [ip]
                     if hasattr(board, 'mta_iface'):
                         try:
                             ip = board.get_interface_ipaddr(board.mta_iface)
                         except:
-                            assert ipaddress.IPv4Address(ip.decode('utf-8')) in prov.mta_network, \
-                                "Board failed to obtain MTA IP address"
+                            continue
+
+                        assert ipaddress.IPv4Address(ip.decode('utf-8')) in prov.mta_network, \
+                            "Board failed to obtain MTA IP address"
                         ips += [ip]
-                        break
+
+                    break
                 except:
                     if time.time() - start_time < time_for_provisioning:
                         raise


### PR DESCRIPTION
We can't run the assert if we don't have an IP, we should just loop
again

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>