### PR TITLE
devices: base: enahnaced "enable_ipv6" function

### DIFF
--- a/devices/base.py
+++ b/devices/base.py
@@ -245,6 +245,8 @@ class BaseDevice(pexpect.spawn):
         pass
 
     def enable_ipv6(self, interface):
+        self.sendline("sysctl net.ipv6.conf."+interface+".accept_ra=2")
+        self.expect(self.prompt, timeout=30)
         self.sendline("sysctl net.ipv6.conf."+interface+".disable_ipv6=0")
         self.expect(self.prompt, timeout=30)
 


### PR DESCRIPTION
     - Added code to enable sysctl knob to accept router advertisement
     - accept_ra value is set to 2 which override ipv6 forwarding rule
       and accepts ra

Signed-off-by: prekumar.contractor<prekumar.contractor@libertyglobal.com>