### PR TITLE
Pr cmts prompt regex issue

### DIFF
--- a/devices/casa_cmts.py
+++ b/devices/casa_cmts.py
@@ -41,12 +41,12 @@ class CasaCMTS(base.BaseDevice):
 
     def connect(self):
         try:
-            self.expect([re.escape("Escape character is '^]'.'"), pexpect.TIMEOUT], timeout=10)
-            if 2 != self.expect(['\r\n(.*) login:', '(.*) login:', pexpect.TIMEOUT], timeout=10):
-                hostname = self.match.group(1).replace('\n', '').replace('\r', '').strip()
-                self.prompt.append(hostname + '>')
-                self.prompt.append(hostname + '#')
-                self.prompt.append(hostname + '\(.*\)#')
+            idx=self.expect(['(\r\n)?(.*) login:', pexpect.TIMEOUT], timeout=20)
+            if 0 == idx:
+                hostname = self.match.group(2).replace('\n', '').replace('\r', '')
+                if hostname + '>' not in self.prompt: self.prompt.append(hostname + '>')
+                if hostname + '#' not in self.prompt: self.prompt.append(hostname + '#')
+                if hostname + '\(.*\)#' not in self.prompt: self.prompt.append(hostname + '\(.*\)#')
                 self.sendline(self.username)
                 self.expect('assword:')
                 self.sendline(self.password)

--- a/devices/local_serial_connection.py
+++ b/devices/local_serial_connection.py
@@ -1,4 +1,5 @@
 import pexpect
+from lib.regexlib import telnet_ipv4_conn
 
 class LocalSerialConnection():
     '''
@@ -15,7 +16,7 @@ class LocalSerialConnection():
                            command='/bin/bash',
                            args=['-c', self.conn_cmd])
         try:
-            result = self.device.expect([".*Connected.*", "----------------------------------------------------"])
+            result = self.device.expect([telnet_ipv4_conn, "----------------------------------------------------"])
         except pexpect.EOF as e:
             raise Exception("Board is in use (connection refused).")
 

--- a/tests/lib/regexlib.py
+++ b/tests/lib/regexlib.py
@@ -52,3 +52,14 @@ TracerouteNoRoute='((.[1-9]|[1-9][0-9])(\s\s\*\s\*\s\*)(\r\n|\r|\n)){30}'
 #Grep hex string format of Mac address in SNMP output
 #Matches eg:F4 6D 04 61 74 E0
 SNMPMacAddressRegex = '([0-9A-Z][0-9A-Z]\s){6}'
+
+'''
+This will match the follwing:
+
+Trying x.x.x.x...
+Connected to x.x.x.x.
+Escape character is '^]'.
+
+'''
+telnet_ipv4_conn="Trying "+ValidIpv4AddressRegex+"\.\.\.\r\nConnected to "+ValidIpv4AddressRegex+"\.\r\nEscape character is '\^]'\.((\r\n){,2})"
+


### PR DESCRIPTION
this should avoid part of the telnet login message ending up in the casa cmts prompt list.
tested on 3 different versions of casa (3000, 3200,10G)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lgirdk/boardfarm/286)
<!-- Reviewable:end -->
