### PR TITLE
devices: base: set_printk is wrapped in a try/except block

### DIFF
--- a/devices/base.py
+++ b/devices/base.py
@@ -250,8 +250,10 @@ class BaseDevice(pexpect.spawn):
         self.expect(self.prompt, timeout=30)
 
     def set_printk(self, CUR=1, DEF=1, MIN=1, BTDEF=7):
-        self.sendline('echo "%d %d %d %d" > /proc/sys/kernel/printk'% (CUR, DEF, MIN, BTDEF))
-        self.expect(self.prompt)
-        if not BFT_DEBUG:
-            common.print_bold("printk set to %d %d %d %d" % (CUR, DEF, MIN, BTDEF))
-
+        try:
+            self.sendline('echo "%d %d %d %d" > /proc/sys/kernel/printk'% (CUR, DEF, MIN, BTDEF))
+            self.expect(self.prompt, timeout=10)
+            if not BFT_DEBUG:
+                common.print_bold("printk set to %d %d %d %d" % (CUR, DEF, MIN, BTDEF))
+        except:
+            pass


### PR DESCRIPTION
Signed-off-by: Michele Gualco <mgualco.contractor@libertyglobal.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lgirdk/boardfarm/289)
<!-- Reviewable:end -->
