### PR TITLE
tests: lib: network_testing: Added generic functions for network testing

### DIFF
--- a/tests/lib/network_testing.py
+++ b/tests/lib/network_testing.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2015
+#
+# All rights reserved.
+#
+# This file is distributed under the Clear BSD license.
+# The full text can be found in LICENSE in the root directory.
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
+
+import re
+
+def tcpdump_capture(device, ip_address, port, capture_file):
+    device.sendline("tcpdump -i %s -n \'portrange %s\' -w /tmp/%s &" %(ip_address, port, capture_file))
+    device.expect(device.prompt)
+    return device.before
+
+def kill_process(device, process="tcpdump"):
+    device.sendline("killall %s" %process)
+    device.expect(device.prompt)
+    return device.before
+
+def tcpdump_read(device, capture_file):
+    device.sendline("tcpdump -n -r /tmp/%s" %(capture_file))
+    device.expect(device.prompt)
+    output = device.before
+    device.sendline("rm /tmp/%s" %(capture_file))
+    device.expect(device.prompt)
+    return output
+
+def nmap_cli(device, ip_address, port, protocol=None, retry="0"):
+    if protocol == "tcp":
+        device.sendline("nmap -sS %s -p %s -Pn -r -max-retries %s" %(ip_address,port,retry))
+    elif protocol == "udp":
+        device.sendline("nmap -sU %s -p %s -Pn -r -max-retries %s" %(ip_address,port,retry))
+    else:
+        device.sendline("nmap -sS -sU %s -p %s -Pn -r -max-retries %s" %(ip_address,port,retry))
+    device.expect(device.prompt,timeout=200)
+    return device.before
+
+def ping(device, ping_ip, ping_interface=None, count=4):
+    if ping_interface == None:
+        device.sendline("ping -c %s %s"%(count,ping_ip))
+    else:
+        device.sendline("ping -I %s -c %s %s"%(ping_interface,count,ping_ip))
+    device.expect(device.prompt, timeout=50)
+    match = re.search("%s packets transmitted, %s received, 0%% packet loss" % (count, count), device.before)
+    if match:
+        return True
+    else:
+        return False


### PR DESCRIPTION
tcpdump_capture() - Start the tcpdump capture
tcpdump_read() - Read the tcpdump capture
nmap_cli() - Execute the nmpa cli
kill_process() - Kill the process
ping() - ping of an IP

This change is required as per comments provided for the commit http://172.16.1.237:8080/c/boardfarm-cbn/+/2934

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lgirdk/boardfarm/309)
<!-- Reviewable:end -->
