### PR TITLE
tests: lib: common: modified snmp_mib_get for additional space

### DIFF
--- a/tests/lib/common.py
+++ b/tests/lib/common.py
@@ -444,7 +444,7 @@ def snmp_mib_get(device, board, iface_ip, mib_name, index, timeout=10, retry=3):
     assert idx==1,"Getting the mib %s"% mib_name
     snmp_out = device.match.group(1)
     device.expect(device.prompt)
-    snmp_out = snmp_out.strip("\"")
+    snmp_out = snmp_out.strip("\"").strip()
     return snmp_out
 
 def hex2ipv6(hexstr):


### PR DESCRIPTION
   - The match group result has the additional space at the end
   - Modified the match group to fetch without space

Signed-off-by: prekumar.contractor <prekumar.contractor@libertyglobal.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lgirdk/boardfarm/311)
<!-- Reviewable:end -->
