### PR TITLE
Add python-tk to travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
         - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
         - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
         - sudo apt-get -qq update
-        - sudo apt-get install -y qemu-system-x86 docker-ce
+        - sudo apt-get install -y qemu-system-x86 docker-ce python-tk
         - sudo apt-get install -y libsnmp-dev snmp-mibs-downloader
 script:
         - ./bft -l


### PR DESCRIPTION
Without this package, a user can hit this error:

  File "/home/ubuntu/boardfarm/devices/debian_isc.py", line 5, in <module>
    from lib.docsis import docsis, cm_cfg
  File "/home/ubuntu/boardfarm/devices/../tests/lib/docsis.py", line 11, in <module>
    import Tkinter
  File "/usr/lib/python2.7/lib-tk/Tkinter.py", line 42, in <module>
    raise ImportError, str(msg) + ', please install the python-tk package'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lgirdk/boardfarm/319)
<!-- Reviewable:end -->
