### PR TITLE
Fix 'Failed to run ... parse' message

### DIFF
--- a/tests/cdrouter_bootstrap.py
+++ b/tests/cdrouter_bootstrap.py
@@ -326,7 +326,7 @@ testvar wanDnsServer %s""" % (self.config.board['cdrouter_wanispip'], \
     @staticmethod
     @lib.common.run_once
     def parse(config):
-        if 'cdrouter_server' in config.board:
+        if hasattr(config, 'board') and 'cdrouter_server' in config.board:
             cdrouter_server = config.board['cdrouter_server']
         elif config.cdrouter_server is not None:
             cdrouter_server = config.cdrouter_server


### PR DESCRIPTION
Just listing tests using "./bft -l" printed an error message at top:

    Failed to run <class 'tests.cdrouter_bootstrap.CDrouterCustom'> parse function!

Due to this:

    Traceback (most recent call last):
      File "/home/mikea/boardfarm/tests/__init__.py", line 50, in init
        new_tests = test.parse(config) or []
      File "/home/mikea/boardfarm/tests/lib/common.py", line 33, in wrapper
        return f(*args, **kwargs)
      File "/home/mikea/boardfarm/tests/cdrouter_bootstrap.py", line 329, in parse
        if 'cdrouter_server' in config.board:
    AttributeError: 'module' object has no attribute 'board'

This code change fixes that.

Signed-off-by: Mike Anderson <mbanderson@uwalumni.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lgirdk/boardfarm/323)
<!-- Reviewable:end -->
