### PR TITLE
fix(devices.py): add specification for boardfarm_server_boot_async()

### DIFF
--- a/boardfarm3/plugins/hookspecs/devices.py
+++ b/boardfarm3/plugins/hookspecs/devices.py
@@ -61,6 +61,25 @@ def boardfarm_server_boot(
     :type device_manager: DeviceManager
     """
 
+@hookspec
+async def boardfarm_server_boot_async(
+    config: BoardfarmConfig,
+    cmdline_args: Namespace,
+    device_manager: DeviceManager,
+) -> None:
+    """Boot boardfarm server device.
+
+    This hook should be used to boot a device which is not dependent on other
+    devices in the environment. E.g. WAN and CMTS.
+
+    :param config: boardfarm config instance
+    :type config: BoardfarmConfig
+    :param cmdline_args: command line arguments
+    :type cmdline_args: Namespace
+    :param device_manager: device manager instance
+    :type device_manager: DeviceManager
+    """
+
 
 @hookspec
 def boardfarm_skip_boot(


### PR DESCRIPTION
without this change, when an environment without server devices, the framework tries to call it, but the method is not defined, leading to a stack trace...